### PR TITLE
fix: Move cursor to after empty line spacing when adding divider

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -381,8 +381,8 @@ $$
         // Replace selection or insert at cursor
         textarea.value = before + divider + after;
 
-        // Move cursor to end of inserted divider (before the final spacing)
-        const newCursorPos = start + divider.length - spacingAfter.length;
+        // Move cursor to end of inserted divider (after the final spacing)
+        const newCursorPos = start + divider.length;
         textarea.selectionStart = newCursorPos;
         textarea.selectionEnd = newCursorPos;
 


### PR DESCRIPTION
  🛠️ Fixed cursor positioning issue in `addDivider()` function
  📍 Previously cursor was placed before the final spacing after divider
  📍 Now cursor correctly moves to after the second newline (empty line spacing)
  🔧 Updated line 385: Changed `start + divider.length - spacingAfter.length` to
   `start + divider.length`
  📝 Updated comment to reflect "after the final spacing" instead of "before the
   final spacing"

  **Impact:** Users can now immediately start typing new content in the empty
  line after inserting a divider with the "Add divider here" button.