### PR TITLE
feat: add direct PDF opening functionality

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -4,7 +4,7 @@ import logging
 from flask import Blueprint, render_template, request, jsonify, send_file, redirect, url_for, flash
 from werkzeug.utils import secure_filename
 from config import Config
-from utils import allowed_file, convert_markdown_to_pdf, convert_markdown_text_to_pdf, cancel_conversion
+from utils import allowed_file, convert_markdown_to_pdf, convert_markdown_text_to_pdf, cancel_conversion, open_file_with_default_app
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -195,6 +195,22 @@ def download_file(filename):
         return jsonify({'error': 'File not found'}), 404
 
     return send_file(file_path, as_attachment=True, download_name=filename)
+
+
+@main.route('/open/<filename>')
+def open_file(filename):
+    """Open converted PDF file with default application."""
+    ensure_directories()
+    file_path = os.path.join(Config.OUTPUT_FOLDER, filename)
+
+    if not os.path.exists(file_path):
+        return jsonify({'error': 'File not found'}), 404
+
+    success, message = open_file_with_default_app(file_path)
+    if success:
+        return jsonify({'success': True, 'message': message})
+    else:
+        return jsonify({'error': message}), 500
 
 
 @main.route('/api/config-presets')

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -424,6 +424,11 @@ body {
     color: var(--text-on-primary);
 }
 
+.btn-info {
+    background: var(--color-info);
+    color: var(--text-on-primary);
+}
+
 .btn-error {
     background: var(--color-error);
     color: var(--text-on-primary);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -28,6 +28,7 @@ class MarkdownToPDFConverter {
         this.resultArea = document.getElementById('result-area');
         this.errorArea = document.getElementById('error-area');
         this.downloadLink = document.getElementById('download-link');
+        this.openLink = document.getElementById('open-link');
         this.newConversionBtn = document.getElementById('new-conversion');
         this.dismissErrorBtn = document.getElementById('dismiss-error');
         this.loadingOverlay = document.getElementById('loading-overlay');
@@ -60,6 +61,7 @@ class MarkdownToPDFConverter {
         this.currentPreset = null;
         this.abortController = null;
         this.currentRequestId = null;
+        this.currentOutputFilename = null;
 
         this.init();
     }
@@ -526,6 +528,11 @@ $$
             this.resetConversion();
         });
 
+        // Open file button
+        this.openLink.addEventListener('click', () => {
+            this.openFile();
+        });
+
         // Dismiss error button
         this.dismissErrorBtn.addEventListener('click', () => {
             this.hideError();
@@ -651,6 +658,35 @@ $$
         this.downloadLink.href = downloadUrl;
         this.resultArea.classList.remove('hidden');
         this.errorArea.classList.add('hidden');
+
+        // Extract filename from download URL for open functionality
+        // URL format: /download/filename.pdf
+        const parts = downloadUrl.split('/');
+        this.currentOutputFilename = parts[parts.length - 1];
+    }
+
+    async openFile() {
+        if (!this.currentOutputFilename) {
+            this.showError('No PDF file available to open.');
+            return;
+        }
+
+        try {
+            // Send request to open file with default application
+            const response = await fetch(`/open/${this.currentOutputFilename}`);
+            const result = await response.json();
+
+            if (result.success) {
+                // Show success message but keep result area visible
+                // Could show a temporary notification, but for now just log
+                console.log('Open request successful:', result.message);
+            } else {
+                this.showError(`Failed to open file: ${result.error || result.message}`);
+            }
+        } catch (error) {
+            console.error('Open request failed:', error);
+            this.showError('Network error while trying to open file.');
+        }
     }
 
     showError(message) {
@@ -670,6 +706,7 @@ $$
         this.updateTextStats();
         this.resetConfiguration();
         this.switchTab('file-tab');
+        this.currentOutputFilename = null;
     }
 
     async cancelConversion() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -241,6 +241,9 @@ print('Code block')
                 <a id="download-link" class="btn btn-success" href="#" target="_blank">
                     <i class="fas fa-download"></i> Download PDF
                 </a>
+                <button id="open-link" class="btn btn-info">
+                    <i class="fas fa-external-link-alt"></i> Open Directly
+                </button>
                 <button class="btn" id="new-conversion">
                     <i class="fas fa-plus"></i> New Conversion
                 </button>

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import subprocess
 import tempfile
 import shutil
@@ -209,5 +210,39 @@ def convert_markdown_text_to_pdf(
 
     except Exception as e:
         error_msg = f"Error in text conversion: {str(e)}"
+        logger.error(error_msg)
+        return False, error_msg
+
+
+def open_file_with_default_app(file_path: str) -> Tuple[bool, str]:
+    """
+    Open a file with the default application for the current platform.
+
+    Returns (success, message).
+    """
+    try:
+        if not os.path.exists(file_path):
+            return False, f"File not found: {file_path}"
+
+        platform_name = platform.system().lower()
+
+        if platform_name == 'windows':
+            os.startfile(file_path)
+            return True, f"Opened {file_path} with default application"
+        elif platform_name == 'darwin':  # macOS
+            subprocess.Popen(['open', file_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True, f"Opened {file_path} with default application"
+        elif platform_name == 'linux':
+            subprocess.Popen(['xdg-open', file_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True, f"Opened {file_path} with default application"
+        else:
+            return False, f"Unsupported platform: {platform_name}"
+
+    except FileNotFoundError:
+        error_msg = f"Command not found. Please ensure 'open' (macOS) or 'xdg-open' (Linux) is installed."
+        logger.error(error_msg)
+        return False, error_msg
+    except Exception as e:
+        error_msg = f"Error opening file: {str(e)}"
         logger.error(error_msg)
         return False, error_msg


### PR DESCRIPTION
fixes #3  
 ✨ Added backend endpoint `/open/<filename>` to open PDF files with default
  system application using platform-specific commands:
    - Windows: `os.startfile()`
    - macOS: `open` command
    - Linux: `xdg-open` command

  🖥️ Updated frontend UI to include "Open Directly" button alongside existing
  download button in result area:
    - Added new button with `btn-info` styling
    - Implemented JavaScript handler for open requests
    - Stored PDF filename for open functionality

  🔧 Backend changes:
    - Added `open_file_with_default_app()` utility function in `utils.py`
    - Registered new route in `routes.py`
    - Used `subprocess.Popen` for non-blocking file opening on Unix systems

  📝 Frontend changes:
    - Modified `index.html` to add open button
    - Extended `main.js` with `openFile()` method and event handling
    - Added `.btn-info` CSS class in `style.css`

  🚀 Users can now open converted PDFs directly without downloading first, while
   retaining the existing download functionality.