### PR TITLE
fix: Make theme always follow system changes and reset on page reload

### DIFF
--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,6 +1,7 @@
 /**
  * Theme management for Markdown to PDF Converter
- * Supports system preference detection and manual toggle
+ * Follows system theme by default, allows manual override during session
+ * Manual changes are not persisted across page reloads
  */
 
 class ThemeManager {
@@ -14,7 +15,7 @@ class ThemeManager {
     }
 
     init() {
-        // Set initial theme based on localStorage or system preference
+        // Set initial theme based on system preference
         this.setInitialTheme();
 
         // Add event listener for toggle button
@@ -27,15 +28,8 @@ class ThemeManager {
     }
 
     setInitialTheme() {
-        const storedTheme = localStorage.getItem('theme');
-
-        if (storedTheme) {
-            // Use stored theme
-            this.setTheme(storedTheme);
-        } else {
-            // Use system preference
-            this.setTheme(this.getSystemTheme());
-        }
+        // Always use system preference on page load
+        this.setTheme(this.getSystemTheme());
     }
 
     getSystemTheme() {
@@ -48,9 +42,6 @@ class ThemeManager {
 
         // Update icon visibility
         this.updateIcons(theme);
-
-        // Store preference
-        localStorage.setItem('theme', theme);
 
         // Dispatch custom event for other components
         window.dispatchEvent(new CustomEvent('themechange', { detail: { theme } }));
@@ -80,17 +71,14 @@ class ThemeManager {
         // Use modern addEventListener if available
         if (mediaQuery.addEventListener) {
             mediaQuery.addEventListener('change', (e) => {
-                // Only follow system preference if no manual override
-                if (!localStorage.getItem('theme')) {
-                    this.setTheme(e.matches ? 'dark' : 'light');
-                }
+                // Always follow system theme changes
+                this.setTheme(e.matches ? 'dark' : 'light');
             });
         } else {
             // Fallback for older browsers
             mediaQuery.addListener((e) => {
-                if (!localStorage.getItem('theme')) {
-                    this.setTheme(e.matches ? 'dark' : 'light');
-                }
+                // Always follow system theme changes
+                this.setTheme(e.matches ? 'dark' : 'light');
             });
         }
     }


### PR DESCRIPTION
fixes #9 
- **Removed localStorage persistence**: Manual theme changes are no longer stored across page reloads
- **Always use system theme on page load**: Every fresh page load now starts with the system theme preference
- **Always follow system theme changes**: System theme changes now immediately override any manual theme selection 
- **Manual toggle still works**: Users can still manually toggle theme during a session, but changes are session-only

| Before | After |
|--------|-------|
| Manual toggle persisted across reloads | Manual changes lost on page reload | | System changes ignored after manual toggle | System changes always override manual selection | | Page reload kept manual preference | Page reload resets to system theme |

1. **Removed** all `localStorage.getItem('theme')` checks in `setInitialTheme()` and `watchSystemTheme()`
2. **Removed** `localStorage.setItem('theme', theme)` in `setTheme()`
3. **Updated** comments to reflect new behavior
4. **Simplified** logic to follow "last trigger wins" principle

The previous behavior conflicted with user expectations where:
- System theme changes should always be followed
- Manual toggles should work but not persist indefinitely
- Page reloads should return to system default

Now the theme follows a simple rule: **The last trigger (system or user) wins, but page reload resets to system preference.** Γ£à